### PR TITLE
fix: correcao do erro ao realizar autenticação offline

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-718479316">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.0" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-522058509">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.0" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="insertAndGetUserByEmail()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,4 +62,15 @@ dependencies {
     val room_version = "2.7.2"
     implementation("androidx.room:room-runtime:$room_version")
     annotationProcessor("androidx.room:room-compiler:$room_version")
+
+    // Para testes de unidade
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:4.8.0") // Mockito para simular objetos
+    testImplementation("org.robolectric:robolectric:4.9") // Robolectric para testes que precisam de Android framework (como Context)
+
+    // Para testes do Room
+    androidTestImplementation("androidx.room:room-testing:2.6.1")
+
+    // Para testes de corrotinas
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
 }

--- a/app/src/androidTest/java/com/unip/cc7p33/memorizeflashcardapp/database/UsuarioDAOTest.java
+++ b/app/src/androidTest/java/com/unip/cc7p33/memorizeflashcardapp/database/UsuarioDAOTest.java
@@ -1,0 +1,89 @@
+package com.unip.cc7p33.memorizeflashcardapp.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import android.content.Context;
+
+import androidx.room.Room;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.unip.cc7p33.memorizeflashcardapp.model.Usuario;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(AndroidJUnit4.class)
+public class UsuarioDAOTest {
+
+    private UsuarioDAO usuarioDao;
+    private AppDatabase db;
+
+    @Before
+    public void createDb(){
+        Context context = ApplicationProvider.getApplicationContext();
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase.class).build();
+        usuarioDao = db.usuarioDao();
+    }
+
+    @After
+    public void closeDb() throws IOException {
+        db.close();
+    }
+
+    @Test
+    public void insertAndGetUserByEmail(){
+        Usuario usuario = new Usuario("Test user", "test@example.com");
+        usuario.setUid("12345");
+
+        // Insere o usuário
+        usuarioDao.insertUser(usuario);
+
+        // Busca o usuário pelo email
+        Usuario found = usuarioDao.getUserByEmail("test@example.com");
+
+        // Verifica se o usuário foi encontrado e se os dados estão corretos
+        assertNotNull(found);
+        assertEquals(found.getEmail(), usuario.getEmail());
+    }
+
+    @Test
+    public void insertAndGetUserByUID() {
+        Usuario usuario = new Usuario("Another User", "another@example.com");
+        usuario.setUid("67890");
+
+        // Insere o usuário
+        usuarioDao.insertUser(usuario);
+
+        // Busca o usuário pelo UID
+        Usuario found = usuarioDao.getUserByUID("67890");
+
+        // Verifica se o usuário foi encontrado e se os dados estão corretos
+        assertNotNull(found);
+        assertEquals(found.getUid(), usuario.getUid());
+    }
+
+    @Test
+    public void deleteAllUsers() {
+        Usuario usuario1 = new Usuario("User One", "user1@example.com");
+        usuario1.setUid("uid1");
+        Usuario usuario2 = new Usuario("User Two", "user2@example.com");
+        usuario2.setUid("uid2");
+
+        usuarioDao.insertUser(usuario1);
+        usuarioDao.insertUser(usuario2);
+
+        // Deleta todos os usuários
+        usuarioDao.deleteAllUsers();
+
+        // Tenta buscar um dos usuários, deve retornar nulo
+        Usuario found1 = usuarioDao.getUserByEmail("user1@example.com");
+        assertNull(found1);
+    }
+}

--- a/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/service/AuthService.java
+++ b/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/service/AuthService.java
@@ -12,6 +12,8 @@ import com.unip.cc7p33.memorizeflashcardapp.repository.AuthRepository;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class AuthService {
 
@@ -28,7 +30,7 @@ public class AuthService {
     public AuthService(Context context){
         mAuth = FirebaseAuth.getInstance();
         db = FirebaseFirestore.getInstance();
-        authRepository = new AuthRepository(context);
+        authRepository = new AuthRepository(context); // Chama o construtor correto
         this.context = context;
     }
 
@@ -92,12 +94,17 @@ public class AuthService {
                     });
         } else {
             // Se não houver internet, tenta buscar o usuário localmente
-            Usuario usuarioLocal = authRepository.getUserByEmail(email);
-            if (usuarioLocal != null) {
-                callback.onSuccess(usuarioLocal);
-            } else {
-                callback.onFailure("Sem conexão com a internet. E-mail não encontrado no banco de dados local.");
-            }
+            authRepository.getUserByEmail(email, new AuthRepository.GetUserCallback() {
+                @Override
+                public void onUserFound(Usuario usuario) {
+                    callback.onSuccess(usuario);
+                }
+
+                @Override
+                public void onUserNotFound() {
+                    callback.onFailure("Sem conexão com a internet. E-mail não encontrado no banco de dados local");
+                }
+            });
         }
     }
 

--- a/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/view/LoginActivity.java
+++ b/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/view/LoginActivity.java
@@ -42,10 +42,10 @@ public class LoginActivity extends AppCompatActivity {
         authService = new AuthService(this);
 
         // Redireciona para a tela principal se o usuário já estiver logado
-//        if (authService.getCurrentUser() != null) {
-//            startActivity(new Intent(LoginActivity.this, MainActivity.class));
-//            finish();
-//        }
+        if (authService.getCurrentUser() != null) {
+            startActivity(new Intent(LoginActivity.this, MainActivity.class));
+            finish();
+        }
 
         btnLogin.setOnClickListener(v -> {
             String email = editTextEmail.getText().toString().trim();

--- a/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/view/MainActivity.java
+++ b/app/src/main/java/com/unip/cc7p33/memorizeflashcardapp/view/MainActivity.java
@@ -1,13 +1,6 @@
 package com.unip.cc7p33.memorizeflashcardapp.view;
-
 import android.os.Bundle;
-
-import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
-
 import com.unip.cc7p33.memorizeflashcardapp.R;
 
 public class MainActivity extends AppCompatActivity {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,13 +7,4 @@
     android:layout_height="match_parent"
     tools:context=".view.MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/unip/cc7p33/memorizeflashcardapp/repository/AuthRepositoryTest.java
+++ b/app/src/test/java/com/unip/cc7p33/memorizeflashcardapp/repository/AuthRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.unip.cc7p33.memorizeflashcardapp.repository;
+
+import com.unip.cc7p33.memorizeflashcardapp.database.AppDatabase;
+import com.unip.cc7p33.memorizeflashcardapp.database.UsuarioDAO;
+import com.unip.cc7p33.memorizeflashcardapp.model.Usuario;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest=Config.NONE)
+public class AuthRepositoryTest {
+
+    // Mock do Context, necessário para instanciar o AuthRepository
+    @Mock
+    private android.content.Context mockContext;
+
+    // Mock do banco de dados e do DAO
+    @Mock
+    private AppDatabase mockAppDatabase;
+    @Mock
+    private UsuarioDAO mockUsuarioDao;
+
+    // A classe que vamos testar
+    private AuthRepository authRepository;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // Simula o comportamento do AppDatabase para retornar nosso mock do DAO
+        when(mockAppDatabase.usuarioDao()).thenReturn(mockUsuarioDao);
+
+        // Crie uma instância do AuthRepository, mas use um mock para o Context e o AppDatabase
+        // Isso permite que o construtor do AuthRepository seja executado de forma isolada
+        authRepository = new AuthRepository(mockContext) {
+            // Sobrescreve o método getDatabase para retornar o mock do AppDatabase
+            // Isso evita a dependência real do banco de dados
+            @Override
+            public void insertUser(Usuario usuario) {
+                // Remove a chamada ao AsyncTask, testando diretamente o DAO
+                mockUsuarioDao.insertUser(usuario);
+            }
+            @Override
+            public Usuario getUserByEmail(String email) {
+                return mockUsuarioDao.getUserByEmail(email);
+            }
+            @Override
+            public void deleteAllUsers() {
+                // Remove a chamada ao AsyncTask, testando diretamente o DAO
+                mockUsuarioDao.deleteAllUsers();
+            }
+        };
+    }
+
+    @Test
+    public void insertUser_callsDaoMethod() {
+        Usuario usuario = new Usuario("Test Insert", "insert@example.com");
+        usuario.setUid("uidInsert");
+
+        // Chama o método público a ser testado
+        authRepository.insertUser(usuario);
+
+        // Verifica se o método `insertUser` do mock do DAO foi chamado com o usuário correto
+        verify(mockUsuarioDao).insertUser(usuario);
+    }
+
+    @Test
+    public void getUserByEmail_returnsUserFromDao() {
+        Usuario expectedUser = new Usuario("Test Search", "search@example.com");
+        expectedUser.setUid("uidSearch");
+
+        // Simula o comportamento do mock: quando `getUserByEmail` for chamado, ele retornará `expectedUser`
+        when(mockUsuarioDao.getUserByEmail("search@example.com")).thenReturn(expectedUser);
+
+        Usuario foundUser = authRepository.getUserByEmail("search@example.com");
+
+        // Verifica se o usuário retornado é o mesmo que o mock retornou
+        assertNotNull(foundUser);
+        assertEquals(expectedUser.getEmail(), foundUser.getEmail());
+    }
+
+    @Test
+    public void deleteAllUsers_callsDaoMethod() {
+        // Chama o método público a ser testado
+        authRepository.deleteAllUsers();
+
+        // Verifica se o método `deleteAllUsers` do mock do DAO foi chamado
+        verify(mockUsuarioDao).deleteAllUsers();
+    }
+}

--- a/app/src/test/java/com/unip/cc7p33/memorizeflashcardapp/service/AuthServiceTest.java
+++ b/app/src/test/java/com/unip/cc7p33/memorizeflashcardapp/service/AuthServiceTest.java
@@ -1,0 +1,178 @@
+package com.unip.cc7p33.memorizeflashcardapp.service;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.unip.cc7p33.memorizeflashcardapp.model.Usuario;
+import com.unip.cc7p33.memorizeflashcardapp.repository.AuthRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest=Config.NONE)
+public class AuthServiceTest {
+
+    @Mock
+    private Context mockContext;
+    @Mock
+    private FirebaseAuth mockFirebaseAuth;
+    @Mock
+    private FirebaseFirestore mockFirestore;
+    @Mock
+    private AuthRepository mockAuthRepository;
+    @Mock
+    private ConnectivityManager mockConnectivityManager;
+    @Mock
+    private NetworkInfo mockNetworkInfo;
+    @Mock
+    private Task<AuthResult> mockAuthTask;
+    @Mock
+    private Task<DocumentSnapshot> mockFirestoreTask;
+    @Mock
+    private Task<Void> mockSetTask;
+    @Mock
+    private FirebaseUser mockFirebaseUser;
+    @Mock
+    private CollectionReference mockCollectionReference;
+    @Mock
+    private DocumentReference mockDocumentReference;
+    @Mock
+    private DocumentSnapshot mockDocumentSnapshot;
+    @Mock
+    private AuthService.AuthCallback mockCallback;
+
+    private AuthService authService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // Simula o contexto para que o ConnectivityManager funcione
+        when(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(mockConnectivityManager);
+        when(mockConnectivityManager.getActiveNetworkInfo()).thenReturn(mockNetworkInfo);
+
+        authService = new AuthService(mockContext) {
+            // Sobrescreve as instâncias para usar os mocks
+            @Override
+            public void registerUser(String email, String password, String nome, AuthCallback callback) {
+                super.registerUser(email, password, nome, callback);
+            }
+
+            @Override
+            public void loginUser(String email, String password, AuthCallback callback) {
+                super.loginUser(email, password, callback);
+            }
+        };
+    }
+
+    // --- Testes para registerUser ---
+
+    @Test
+    public void registerUser_Success_CallbackSuccessCalled() {
+        // Configura mocks para um cenário de sucesso
+        when(mockFirebaseAuth.createUserWithEmailAndPassword(anyString(), anyString())).thenReturn(mockAuthTask);
+        when(mockAuthTask.isSuccessful()).thenReturn(true);
+        when(mockFirebaseAuth.getCurrentUser()).thenReturn(mockFirebaseUser);
+        when(mockFirebaseUser.getUid()).thenReturn("test-uid");
+        when(mockFirestore.collection(anyString())).thenReturn(mockCollectionReference);
+        when(mockCollectionReference.document(anyString())).thenReturn(mockDocumentReference);
+        when(mockDocumentReference.set(any(Usuario.class))).thenReturn(mockSetTask);
+        when(mockSetTask.isSuccessful()).thenReturn(true);
+
+        // Captura o listener de sucesso para simular a chamada
+        ArgumentCaptor<OnSuccessListener> successCaptor = ArgumentCaptor.forClass(OnSuccessListener.class);
+        doAnswer(invocation -> {
+            successCaptor.getValue().onSuccess(null);
+            return mockSetTask;
+        }).when(mockSetTask).addOnSuccessListener(successCaptor.capture());
+
+        // Executa o método a ser testado
+        authService.registerUser("test@example.com", "password123", "Test User", mockCallback);
+
+        // Verifica as interações
+        verify(mockAuthRepository).insertUser(any(Usuario.class));
+        verify(mockCallback).onSuccess(any(Usuario.class));
+        verify(mockCallback, never()).onFailure(anyString());
+    }
+
+    // --- Testes para loginUser ---
+
+    @Test
+    public void loginUser_Online_Success_CallbackSuccessCalled() {
+        // Simula a conexão com a internet
+        when(mockNetworkInfo.isConnectedOrConnecting()).thenReturn(true);
+
+        // Configura mocks para login bem-sucedido
+        when(mockFirebaseAuth.signInWithEmailAndPassword(anyString(), anyString())).thenReturn(mockAuthTask);
+        when(mockAuthTask.isSuccessful()).thenReturn(true);
+        when(mockFirebaseAuth.getCurrentUser()).thenReturn(mockFirebaseUser);
+        when(mockFirebaseUser.getUid()).thenReturn("test-uid");
+        when(mockFirestore.collection(anyString())).thenReturn(mockCollectionReference);
+        when(mockCollectionReference.document(anyString())).thenReturn(mockDocumentReference);
+        when(mockDocumentReference.get()).thenReturn(mockFirestoreTask);
+
+        when(mockFirestoreTask.isSuccessful()).thenReturn(true);
+
+        // Simula a resposta do Firestore
+        when(mockDocumentSnapshot.exists()).thenReturn(true);
+        Usuario expectedUser = new Usuario("Test Login", "login@example.com");
+        expectedUser.setUid("test-uid");
+        when(mockDocumentSnapshot.toObject(Usuario.class)).thenReturn(expectedUser);
+
+        // Captura o listener de sucesso do Firestore
+        ArgumentCaptor<OnSuccessListener> successCaptor = ArgumentCaptor.forClass(OnSuccessListener.class);
+        doAnswer(invocation -> {
+            successCaptor.getValue().onSuccess(mockDocumentSnapshot);
+            return mockFirestoreTask;
+        }).when(mockFirestoreTask).addOnSuccessListener(successCaptor.capture());
+
+        authService.loginUser("login@example.com", "password123", mockCallback);
+
+        // Verifica se o repositório foi chamado e o callback de sucesso foi acionado
+        verify(mockAuthRepository).insertUser(any(Usuario.class));
+        verify(mockCallback).onSuccess(any(Usuario.class));
+        verify(mockCallback, never()).onFailure(anyString());
+    }
+
+    @Test
+    public void loginUser_Offline_LocalUserFound_CallbackSuccessCalled() {
+        // Simula a falta de conexão
+        when(mockNetworkInfo.isConnectedOrConnecting()).thenReturn(false);
+
+        // Simula que o usuário foi encontrado no banco de dados local
+        Usuario localUser = new Usuario("Local User", "local@example.com");
+        when(mockAuthRepository.getUserByEmail(anyString())).thenReturn(localUser);
+
+        authService.loginUser("local@example.com", "password123", mockCallback);
+
+        // Verifica se a chamada ao Firebase foi ignorada e o callback local foi acionado
+        verify(mockFirebaseAuth, never()).signInWithEmailAndPassword(anyString(), anyString());
+        verify(mockAuthRepository).getUserByEmail("local@example.com");
+        verify(mockCallback).onSuccess(localUser);
+    }
+}


### PR DESCRIPTION
**Issue:** #13 

### Resumo da Correção: Falha ao Fazer Login Offline

**📝 Descrição do Problema:**

> O aplicativo estava falhando com um erro java.lang.IllegalStateException: Cannot access database on the main thread ao tentar fazer login sem conexão com a internet, após o usuário ter saído da conta.
> 
> A lógica de login offline buscava os dados do usuário no banco de dados local (Room). O erro ocorria porque a operação de leitura do banco de dados (AuthRepository.getUserByEmail) estava sendo executada na thread principal (main thread), o que pode travar a interface do usuário. O Android proíbe explicitamente essa prática para evitar "Application Not Responding" (ANR).

**📌 Causa Raiz:**

> A arquitetura original do projeto usava o AuthRepository de forma síncrona. Quando a AuthService detectava a falta de internet, ela chamava o método getUserByEmail do AuthRepository diretamente, bloqueando a thread principal.
> 
> Apesar da primeira tentativa de correção ter introduzido o ExecutorService para tornar a operação assíncrona, a implementação inicial estava confusa, com o AuthService gerenciando as threads do AuthRepository. Isso levava a um erro de compilação, e a correção final mostrou que o problema era ainda mais profundo, relacionado à forma como o AuthRepository era instanciado.

**🛠️ Solução Aplicada:**

> A correção final focou em dois pontos principais para resolver o problema e melhorar a arquitetura:
> 
> Isolamento de Responsabilidade no Repositório: O AuthRepository agora é totalmente responsável por gerenciar suas próprias operações de threading. Ele cria e gerencia seu próprio ExecutorService, garantindo que todas as interações com o banco de dados Room (insert, get, delete) sejam executadas em uma thread de background.
> 
> Transição para Comunicação Assíncrona: O método getUserByEmail em AuthRepository foi refatorado para ser assíncrono. Em vez de retornar um Usuario diretamente, ele agora aceita uma interface de callback (GetUserCallback). O AuthService chama o método e, quando a operação de banco de dados é concluída, o AuthRepository notifica o AuthService através do callback.

**✅ Resultado:**

A correção eliminou o erro fatal, permitindo que o aplicativo faça login offline corretamente. A arquitetura se tornou mais robusta, com a separação clara das responsabilidades: a AuthService lida com a lógica de negócio, e o AuthRepository gerencia as operações de dados em background, sem bloquear a thread principal.

Esta solução garante uma experiência de usuário mais fluida e um código mais sustentável no longo prazo.

